### PR TITLE
Remove duplicated TikTok definition and fix warning

### DIFF
--- a/lib/oembed/providers/builtin_providers.rb
+++ b/lib/oembed/providers/builtin_providers.rb
@@ -205,11 +205,6 @@ module OEmbed
     Ted << "https://*.ted.com/talks/*"
     add_official_provider(Ted)
 
-    # Provider for TikTok
-    # See https://developers.tiktok.com/doc/embed-videos
-    TikTok = OEmbed::Provider.new("https://www.tiktok.com/oembed", format: :json)
-    TikTok << "https://www.tiktok.com/*/video/*"
-
     # Provider for tumblr.com
     Tumblr = OEmbed::Provider.new("http://www.tumblr.com/oembed/1.0/", format: :json)
     Tumblr << "http://*.tumblr.com/post/*"


### PR DESCRIPTION
### Problem

Version 0.16.0 introduced the TikTok provider, but defined the definitions twice:

1) [in `lib/oembed/providers/builtin_providers.rb`](https://github.com/ruby-oembed/ruby-oembed/blob/master/lib/oembed/providers/builtin_providers.rb#L208-L211)
2) [in `lib/oembed/providers/tiktok.rb`](https://github.com/ruby-oembed/ruby-oembed/blob/master/lib/oembed/providers/tiktok.rb)

This is causing warnings whenever our app is booted:

```
vendor/bundle/ruby/2.7.0/gems/ruby-oembed-0.16.0/lib/oembed/providers/builtin_providers.rb:210: warning: already initialized constant OEmbed::Providers::TikTok
vendor/bundle/ruby/2.7.0/gems/ruby-oembed-0.16.0/lib/oembed/providers/tiktok.rb:5: warning: previous definition of TikTok was here
```

[The comments specified](https://github.com/ruby-oembed/ruby-oembed/blob/master/lib/oembed/providers/builtin_providers.rb#L1) you're moving to separate files for each definition, so this PR removes the duplicate in `builtin_providers.rb` in favour of leaving `providers/tiktok.rb`

### Result

No more warnings 😄 